### PR TITLE
Add support for building a Universal binary on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,9 @@
 cmake_minimum_required(VERSION 3.16)
 
 if(APPLE)
+  # Build a Universal binary on macOS
+  # This requires that the found Qt library is compiled as Universal binaries.
   set(CMAKE_OSX_ARCHITECTURES "arm64;x86_64" CACHE STRING "" FORCE)
-  # Specify location of Universal QT installation
-  # can be removed if default install is Universal (won't be the case with Homebrew installed QT)
-  set(Qt6_DIR "~/Qt/6.5.0/macos/lib/cmake/Qt6")
 endif()
 
 project(gpt4all VERSION 0.1.0 LANGUAGES CXX)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,7 +65,6 @@ install(TARGETS chat DESTINATION bin COMPONENT ${COMPONENT_NAME_MAIN})
 
 set(CPACK_GENERATOR "IFW")
 
-message("Before if")
 if(${CMAKE_SYSTEM_NAME} MATCHES Linux)
     set(LINUXDEPLOYQT "/home/atreat/dev/linuxdeployqt/build/tools/linuxdeployqt/linuxdeployqt")
     configure_file("${CMAKE_CURRENT_SOURCE_DIR}/cmake/deploy-qt-linux.cmake.in"
@@ -80,7 +79,6 @@ elseif(${CMAKE_SYSTEM_NAME} MATCHES Windows)
     set(CPACK_IFW_ROOT "C:/Qt/Tools/QtInstallerFramework/4.5")
     set(CPACK_IFW_PACKAGE_ICON "${CMAKE_CURRENT_SOURCE_DIR}/icons/favicon.ico")
 elseif(${CMAKE_SYSTEM_NAME} MATCHES Darwin)
-    message("Yes Darwin")
     find_program(MACDEPLOYQT macdeployqt HINTS ${_qt_bin_dir})
     configure_file("${CMAKE_CURRENT_SOURCE_DIR}/cmake/deploy-qt-mac.cmake.in"
                    "${CMAKE_BINARY_DIR}/cmake/deploy-qt-mac.cmake" @ONLY)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,12 @@
 cmake_minimum_required(VERSION 3.16)
 
+if(APPLE)
+  set(CMAKE_OSX_ARCHITECTURES "arm64;x86_64" CACHE STRING "" FORCE)
+  # Specify location of Universal QT installation
+  # can be removed if default install is Universal (won't be the case with Homebrew installed QT)
+  set(Qt6_DIR "~/Qt/6.5.0/macos/lib/cmake/Qt6")
+endif()
+
 project(gpt4all VERSION 0.1.0 LANGUAGES CXX)
 
 set(CMAKE_AUTOMOC ON)
@@ -58,6 +65,7 @@ install(TARGETS chat DESTINATION bin COMPONENT ${COMPONENT_NAME_MAIN})
 
 set(CPACK_GENERATOR "IFW")
 
+message("Before if")
 if(${CMAKE_SYSTEM_NAME} MATCHES Linux)
     set(LINUXDEPLOYQT "/home/atreat/dev/linuxdeployqt/build/tools/linuxdeployqt/linuxdeployqt")
     configure_file("${CMAKE_CURRENT_SOURCE_DIR}/cmake/deploy-qt-linux.cmake.in"
@@ -72,6 +80,7 @@ elseif(${CMAKE_SYSTEM_NAME} MATCHES Windows)
     set(CPACK_IFW_ROOT "C:/Qt/Tools/QtInstallerFramework/4.5")
     set(CPACK_IFW_PACKAGE_ICON "${CMAKE_CURRENT_SOURCE_DIR}/icons/favicon.ico")
 elseif(${CMAKE_SYSTEM_NAME} MATCHES Darwin)
+    message("Yes Darwin")
     find_program(MACDEPLOYQT macdeployqt HINTS ${_qt_bin_dir})
     configure_file("${CMAKE_CURRENT_SOURCE_DIR}/cmake/deploy-qt-mac.cmake.in"
                    "${CMAKE_BINARY_DIR}/cmake/deploy-qt-mac.cmake" @ONLY)


### PR DESCRIPTION
Small change to enable building a Universal binary on macOS

Note that it requires a Universal version of QT.  An installation through Homebrew (which most macOS users are likely using) will not be Universal.

Instead I needed to manually download the QT distribution, which I put in `~/Qt`.  This location then needs to be referenced in CMakeLists, and I've included an example of that.

Maybe there's a better way to do this, but I have very little CMake experience.  This seems to work anyway! (tested on an Intel macOS build system, which is all I have available to test with atm.)