### PR TITLE
Use completeBaseName to display model name

### DIFF
--- a/llm.cpp
+++ b/llm.cpp
@@ -52,7 +52,7 @@ bool LLMObject::loadModel()
     }
 
     if (m_llmodel) {
-        m_modelName = info.baseName().remove(0, 5); // remove the ggml- prefix
+        m_modelName = info.completeBaseName().remove(0, 5); // remove the ggml- prefix
         emit modelNameChanged();
     }
 


### PR DESCRIPTION
this cuts the filename at the *final* dot instead of the first, allowing model names with version numbers to be displayed correctly.