### PR TITLE
Updated README.md to include CLI-only build instructions. Also change the `git clone` destination to main repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 CMakeLists.txt.user
 models/*
+build/*

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ GPT-J model by following build instructions below.
 * Download https://huggingface.co/EleutherAI/gpt-j-6b
 * Clone this repo and build
 ```
-git clone --recurse-submodules https://github.com/nomic-ai/gpt4all
+git clone --recurse-submodules https://github.com/nomic-ai/gpt4all-chat
 cd gpt4all-chat
 mkdir build
 cd build
@@ -56,7 +56,7 @@ python3 ../ggml/examples/gpt-j/convert-h5-to-ggml.py /path/to/your/local/copy/of
 * Install cmake for your platform https://cmake.org/install/
 * Clone this repo and build the `ggml` subfolder
 ```
-git clone --recurse-submodules https://github.com/nomic-ai/gpt4all
+git clone --recurse-submodules https://github.com/nomic-ai/gpt4all-chat
 cd gpt4all-chat/ggml
 mkdir build
 cd build

--- a/README.md
+++ b/README.md
@@ -51,6 +51,24 @@ python3 ../ggml/examples/gpt-j/convert-h5-to-ggml.py /path/to/your/local/copy/of
 ./chat
 ```
 
+## Building and running CLI tools only (no Qt required)
+
+* Install cmake for your platform https://cmake.org/install/
+* Clone this repo and build the `ggml` subfolder
+```
+git clone --recurse-submodules https://github.com/nomic-ai/gpt4all
+cd gpt4all-chat/ggml
+mkdir build
+cd build
+cmake ..
+cmake --build . --parallel
+wget https://gpt4all.io/models/ggml-gpt4all-j.bin # Download GGML model if required
+./bin/gpt-j -m ggml-gpt4all-j.bin -n 200 --top_k 40 --top_p 0.9 -b 9 --temp 0.9 -p "Below is an instruction that describes a task. Write a response that appropriately completes the request.
+### Instruction:
+Write a story about llamas
+### Response:"
+```
+
 ## Contributing
 
 * Pull requests welcome. See the feature wish list for ideas :)

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ GPT-J model by following build instructions below.
 * Download https://huggingface.co/EleutherAI/gpt-j-6b
 * Clone this repo and build
 ```
-git clone --recurse-submodules https://github.com/manyoso/gpt4all-chat.git
+git clone --recurse-submodules https://github.com/nomic-ai/gpt4all
 cd gpt4all-chat
 mkdir build
 cd build

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ cmake --build . --parallel
 wget https://gpt4all.io/models/ggml-gpt4all-j.bin # Download GGML model if required
 ./bin/gpt-j -m ggml-gpt4all-j.bin -n 200 --top_k 40 --top_p 0.9 -b 9 --temp 0.9 -p "Below is an instruction that describes a task. Write a response that appropriately completes the request.
 ### Instruction:
-Write a story about llamas
+Tell me about artifical intelligence
 ### Response:"
 ```
 


### PR DESCRIPTION
1. Add instructions for how to build the CLI tools, which does not require a Qt installation.

2. In the instructions for "Building and running", I changed the `git clone` destination to `nomic-ai/gpt4all-chat`. Previously this referenced the `manyoso/gpt4all-chat` repo, which I thought might have been a mistake/oversight.  It would mean that the user could pull newer code than they can see in the main repo, which could be confusing or could cause them to get changes not yet considered ready for merging into the main repo.

Unrelated: I added `build/*` to `.gitignore` so any local build doesn't show up in `git status`