### PR TITLE
readme: GPL -> MIT license

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,6 @@ of download overhead. You can deselect webassembly target, android, sources, etc
 
 
 ## License
-The source code of this chat interface is currently under a GPL license. The underlying GPT4All-j model is released under non-restrictive open-source Apache 2 License.
+The source code of this chat interface is currently under a MIT license. The underlying GPT4All-j model is released under non-restrictive open-source Apache 2 License.
 
 The GPT4All-J license allows for users to use generated outputs as they see fit. Users take responsibility for ensuring their content meets applicable requirements for publication in a given context or region.


### PR DESCRIPTION
The last commit https://github.com/nomic-ai/gpt4all-chat/commit/ef711b305b6b85f6366f15ccce2c10d10df74902 change the license, but this was not reflected in the readme. This PR fixes that.