### PR TITLE
remove fill color for prompt template box

### DIFF
--- a/main.qml
+++ b/main.qml
@@ -216,7 +216,7 @@ Window {
                  Layout.column: 1
                  Layout.fillWidth: true
                  height: 200
-                 color: "#222"
+                 color: "transparent"
                  border.width: 1
                  border.color: "#ccc"
                  radius: 5


### PR DESCRIPTION
fixes unreadable text when system theme is light mode

![image](https://user-images.githubusercontent.com/169252/232652425-67cf6423-03c7-402d-b2cd-9dbde21ea30f.png)
![image](https://user-images.githubusercontent.com/169252/232652495-8270bf0f-bd8b-4194-9a9f-93b1f9bf6660.png)
