### PR TITLE
Fix for issue #90

### DIFF
--- a/main.qml
+++ b/main.qml
@@ -4,6 +4,7 @@ import QtQuick.Controls
 import QtQuick.Controls.Basic
 import QtQuick.Layouts
 import llm
+import Qt.labs.settings 1.1
 
 Window {
     id: window


### PR DESCRIPTION
This fixes issue #90. After including the Qt.labs.settings to the main.qml I no longer get error:

```sh
QQmlApplicationEngine failed to load component
qrc:/gpt4all-chat/main.qml:118:9: Settings is not a type
```