### PR TITLE
Add platform-specific includes

### DIFF
--- a/llmodel/gptj.cpp
+++ b/llmodel/gptj.cpp
@@ -12,7 +12,13 @@
 #include <string>
 #include <vector>
 #include <iostream>
-#include <unistd.h>
+
+// Platform-specific includes
+#ifdef _WIN32
+    #include <windows.h>
+#else
+    #include <unistd.h>
+#endif
 
 // default hparams (GPT-J 6B)
 struct gptj_hparams {

--- a/llmodel/llamamodel.cpp
+++ b/llmodel/llamamodel.cpp
@@ -13,9 +13,15 @@
 #include <string>
 #include <vector>
 #include <iostream>
-#include <unistd.h>
 #include <random>
 #include <thread>
+
+// Platform-specific includes
+#ifdef _WIN32
+    #include <windows.h>
+#else
+    #include <unistd.h>
+#endif
 
 struct LLamaPrivate {
     const std::string modelPath;


### PR DESCRIPTION
On windows we need to include #include <windows.h> and on unix/mac we need #include <unistd.h>.
Fixes issue #113