### PR TITLE
Downloader improvments

### DIFF
--- a/download.cpp
+++ b/download.cpp
@@ -271,7 +271,6 @@ void HashAndSaveFile::hashAndSave(const QString &expectedHash, const QString &sa
     }
 
     QCryptographicHash hash(QCryptographicHash::Md5);
-    hash.addData(tempFile->readAll());
     while(!tempFile->atEnd())
         hash.addData(tempFile->read(16384));
     if (hash.result().toHex() != expectedHash) {

--- a/download.cpp
+++ b/download.cpp
@@ -286,6 +286,14 @@ void HashAndSaveFile::hashAndSave(const QString &expectedHash, const QString &sa
     // The file save needs the tempFile closed
     tempFile->close();
 
+    // Attempt to *move* the verified tempfile into place - this should be atomic
+    // but will only work if the destination is on the same filesystem
+    if (tempFile->rename(saveFilePath)) {
+        tempFile->setAutoRemove(false);
+        emit hashAndSaveFinished(true, tempFile, modelReply);
+        return;
+    }
+
     // Reopen the tempFile for copying
     if (!tempFile->open()) {
         qWarning() << "ERROR: Could not open temp file at finish:"


### PR DESCRIPTION
* Don't `readAll` the whole file into ram to md5 it - the advantage of using a tempfile is so that users don't need two models worth of memory to download additional models
* Atomically move the tempfile into place after verifying it when possible, saving time and avoiding unneeded I/O and disk space usage