### PR TITLE
put chat.exe in 'bin' folder of build tree

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,8 @@ message(STATUS "Qt 6 root directory: ${Qt6_ROOT_DIR}")
 
 add_subdirectory(llmodel)
 
+set (CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+
 qt_add_executable(chat
     main.cpp
     download.h download.cpp


### PR DESCRIPTION
because this is also in llama.cpp's CMakeLists:
https://github.com/ggerganov/llama.cpp/blob/master/CMakeLists.txt#L11 this is where libllama.dll winds up, causing attempts to run the chat UI from Qt Creator on Windows to fail due to not finding libllama.dll - I've been working around this by copying libllama.dll *out* of bin/ but have been bitten a few times by forgetting to keep doing that and the build getting out of sync.