### PR TITLE
use C locale for DoubleValidator

### DIFF
--- a/qml/SettingsDialog.qml
+++ b/qml/SettingsDialog.qml
@@ -193,7 +193,9 @@ The prompt below is a question to answer, a task to complete, or a conversation 
                         ToolTip.visible: hovered
                         Layout.row: 0
                         Layout.column: 1
-                        validator: DoubleValidator {}
+                        validator: DoubleValidator {
+                            locale: "C"
+                        }
                         onEditingFinished: {
                             var val = parseFloat(text)
                             if (!isNaN(val)) {
@@ -228,7 +230,9 @@ The prompt below is a question to answer, a task to complete, or a conversation 
                         ToolTip.visible: hovered
                         Layout.row: 1
                         Layout.column: 1
-                        validator: DoubleValidator {}
+                        validator: DoubleValidator {
+                            locale: "C"
+                        }
                         onEditingFinished: {
                             var val = parseFloat(text)
                             if (!isNaN(val)) {
@@ -375,7 +379,9 @@ The prompt below is a question to answer, a task to complete, or a conversation 
                         ToolTip.visible: hovered
                         Layout.row: 5
                         Layout.column: 1
-                        validator: DoubleValidator {}
+                        validator: DoubleValidator {
+                            locale: "C"
+                        }
                         onEditingFinished: {
                             var val = parseFloat(text)
                             if (!isNaN(val)) {


### PR DESCRIPTION
Closes https://github.com/nomic-ai/gpt4all-chat/issues/126 by making the validator match the behavior of JS parseFloat/toString