### PR TITLE
mpt tokenizer: better special token handling

### DIFF
--- a/llmodel/mpt.cpp
+++ b/llmodel/mpt.cpp
@@ -236,6 +236,7 @@ bool mpt_model_load(const std::string &fname, std::istream &fin, mpt_model & mod
         case 1: wtype = GGML_TYPE_F16;  break;
         case 2: wtype = GGML_TYPE_Q4_0; break;
         case 3: wtype = GGML_TYPE_Q4_1; break;
+        case 5: wtype = GGML_TYPE_Q4_2; break;
         default:
                 {
                     fprintf(stderr, "%s: invalid model file '%s' (bad f16 value %d)\n",


### PR DESCRIPTION
should allow correct handling of the `<|im_start|>` , `<|im_end|>` additional tokens used in the mpt-7b-chat model. See their [demo code](https://huggingface.co/spaces/mosaicml/mpt-7b-chat/blob/main/app.py#L45-L67) for the prompt template.

closer to the behavior of huggingface `tokenizers`, do not attempt to handle additional tokens as if they were part of the original vocabulary as this cannot prevent them from being split into smaller chunks - handle added tokens *before* the regular tokenizing pass

note this is still necessary even with a "proper" tokenizer implementation